### PR TITLE
Include minutes and seconds in certificates duration fields 

### DIFF
--- a/charts/cert-manager-webhook-ionos/Chart.yaml
+++ b/charts/cert-manager-webhook-ionos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0.1"
+appVersion: "1.0.2"
 description: Allow cert-manager to solve DNS challenges using IONOS DNS API 1.0.0 https://developer.hosting.ionos.de/docs/dns
 name: cert-manager-webhook-ionos
-version: 1.0.1
+version: 1.0.2

--- a/charts/cert-manager-webhook-ionos/templates/pki.yaml
+++ b/charts/cert-manager-webhook-ionos/templates/pki.yaml
@@ -29,7 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-ionos.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "cert-manager-webhook-ionos.selfSignedIssuer" . }}
   commonName: "ca.cert-manager-webhook-ionos.cert-manager"
@@ -67,7 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-ionos.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "cert-manager-webhook-ionos.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
cert-manager rewrites the duration field to include minutes and seconds, which is seen as configuration drift by ArgoCD (GitOps tool) and marking as out-of-synch all certificate resources.

See https://github.com/argoproj/argo-cd/issues/6008 which tracks this issue in ArgoCD repo.

This PR normalize the duration fields in Certificates to avoid this ArgoCD synchroinization issue